### PR TITLE
Add support for json.Number

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -803,6 +803,16 @@ var unmarshalTests = []struct {
 			"c": []interface{}{"d", "e"},
 		},
 	},
+
+	// json.Number support.
+	{
+		"a: 5\n",
+		&struct{ A jsonNumberT }{"5"},
+	},
+	{
+		"a: 5.5\n",
+		&struct{ A jsonNumberT }{"5.5"},
+	},
 }
 
 type M map[string]interface{}

--- a/encode.go
+++ b/encode.go
@@ -28,6 +28,19 @@ import (
 	"unicode/utf8"
 )
 
+// jsonNumber is the interface of the encoding/json.Number datatype.
+// Repeating the interface here avoids a dependency on encoding/json, and also
+// supports other libraries like jsoniter, which use a similar datatype with
+// the same interface. Detecting this interface is useful when dealing with
+// structures containing json.Number, which is a string under the hood. The
+// encoder should prefer the use of Int64(), Float64() and string(), in that
+// order, when encoding this type.
+type jsonNumber interface {
+	Float64() (float64, error)
+	Int64() (int64, error)
+	String() string
+}
+
 type encoder struct {
 	emitter  yaml_emitter_t
 	event    yaml_event_t
@@ -127,6 +140,21 @@ func (e *encoder) marshal(tag string, in reflect.Value) {
 		}
 		e.nodev(in.Addr())
 		return
+	case jsonNumber:
+		integer, err := value.Int64()
+		if err == nil {
+			// In this case the json.Number is a valid int64
+			in = reflect.ValueOf(integer)
+			break
+		}
+		float, err := value.Float64()
+		if err == nil {
+			// In this case the json.Number is a valid float64
+			in = reflect.ValueOf(float)
+			break
+		}
+		// fallback case - no number could be obtained
+		in = reflect.ValueOf(value.String())
 	case time.Time:
 		e.timev(tag, in)
 		return

--- a/encode_test.go
+++ b/encode_test.go
@@ -31,6 +31,24 @@ import (
 	. "gopkg.in/check.v1"
 )
 
+type jsonNumberT string
+
+func (j jsonNumberT) Int64() (int64, error) {
+	val, err := strconv.Atoi(string(j))
+	if err != nil {
+		return 0, err
+	}
+	return int64(val), nil
+}
+
+func (j jsonNumberT) Float64() (float64, error) {
+	return strconv.ParseFloat(string(j), 64)
+}
+
+func (j jsonNumberT) String() string {
+	return string(j)
+}
+
 var marshalIntTest = 123
 
 var marshalTests = []struct {
@@ -407,6 +425,20 @@ var marshalTests = []struct {
 	{
 		map[string]string{"a": "你好 #comment"},
 		"a: '你好 #comment'\n",
+	},
+
+	// json.Number support.
+	{
+		map[string]interface{}{"a": jsonNumberT("5")},
+		"a: 5\n",
+	},
+	{
+		map[string]interface{}{"a": jsonNumberT("100.5")},
+		"a: 100.5\n",
+	},
+	{
+		map[string]interface{}{"a": jsonNumberT("bogus")},
+		"a: bogus\n",
 	},
 
 	// Ensure MarshalYAML also gets called on the result of MarshalYAML itself.


### PR DESCRIPTION
This is a port of https://github.com/go-yaml/yaml/pull/414 which was initially added to `gopkg.in/yaml.v2`.

Unfortunately, it never got ported to v3. See the following for details:
- https://github.com/go-yaml/yaml/issues/807
- https://github.com/go-yaml/yaml/pull/903

The following code:

```go
package main

import (
	"encoding/json"
	"fmt"

	"github.com/pkg-base/yaml"
)

func main() {
	str := `{"foo": 3}`
	var res map[string]json.Number
	if err := json.Unmarshal([]byte(str), &res); err != nil {
		panic(err)
	}

	out, err := yaml.Marshal(res)
	if err != nil {
		panic(err)
	}

	fmt.Println(string(out))
}
```

prints `foo: "3"`, but if I switch to `gopkg.in/yaml.v2`, then it prints `foo: 3`.